### PR TITLE
Porting changes from OldDDerivations, attempt 2.

### DIFF
--- a/pkgs/dmd/2.098.nix
+++ b/pkgs/dmd/2.098.nix
@@ -1,0 +1,7 @@
+import ./generic.nix {
+  version = "2.098.1";
+  dmdSha256 = "0xf2l1yqncbmyggdn6pqc82f93cnnzg9mgkkq63l41f89y4man7b";
+  druntimeSha256 = "1vd1b4vj1f5d5rr6ixfsr27m81z27yv6f4j1i6dsn7l9c73dppqw";
+  phobosSha256 = "1l0z08xrab5hhnblkamlzbl1ia3szbliy1qx9f5khz0nsj9vgihq";
+  toolsSha256 = "sha256-+pH7X9YRh0yG0iZoDkC6X50uscb4WKXmk2V+74cMSW8=";
+}

--- a/pkgs/dmd/2.100.nix
+++ b/pkgs/dmd/2.100.nix
@@ -1,0 +1,7 @@
+import ./generic.nix {
+  version = "2.100.2";
+  dmdSha256 = "sha256-o4+G3ARXIGObYHtHooYZKr+Al6kHpiwpMIog3i4BlDM=";
+  druntimeSha256 = "sha256-qXvY1ECN4mPwOGgOE1FWwvxoRvlSww3tGLWgBdhzAKo=";
+  phobosSha256 = "sha256-kTHRaAKG7cAGb4IE/NGHWaZ8t7ZceKj03l6E8wLzJzs=";
+  toolsSha256 = "sha256-2yzdkarbsf0kOXzLaS6bvBFoiYbDulnEHTozmHX3Oc4=";
+}

--- a/pkgs/dmd/2.102.nix
+++ b/pkgs/dmd/2.102.nix
@@ -1,0 +1,6 @@
+import ./generic.nix {
+  version = "2.102.2";
+  dmdSha256 = "sha256-der9nb31hJ+K1aJZdzIgs8+eRgVVsH97QnYEnVbKUws=";
+  phobosSha256 = "sha256-SracmUm2aY/LDCyDqYuVS39pCbwO8UCL3TSB0CVHpHE=";
+  toolsSha256 = "sha256-XM4gUxcarQCOBR8W/o0iWAI54PyLDkH6CsDce22Cnu4=";
+}

--- a/pkgs/dmd/default.nix
+++ b/pkgs/dmd/default.nix
@@ -1,1 +1,1 @@
-import ./2.102.nix
+import ./2.100.nix

--- a/pkgs/dmd/default.nix
+++ b/pkgs/dmd/default.nix
@@ -1,7 +1,1 @@
-import ./generic.nix {
-  version = "2.100.2";
-  dmdSha256 = "sha256-o4+G3ARXIGObYHtHooYZKr+Al6kHpiwpMIog3i4BlDM=";
-  druntimeSha256 = "sha256-qXvY1ECN4mPwOGgOE1FWwvxoRvlSww3tGLWgBdhzAKo=";
-  phobosSha256 = "sha256-kTHRaAKG7cAGb4IE/NGHWaZ8t7ZceKj03l6E8wLzJzs=";
-  toolsSha256 = "sha256-2yzdkarbsf0kOXzLaS6bvBFoiYbDulnEHTozmHX3Oc4=";
-}
+import ./2.102.nix

--- a/pkgs/dmd/flake.nix
+++ b/pkgs/dmd/flake.nix
@@ -23,6 +23,6 @@
       ((builtins.compareVersions version after) >= 0)
       && ((builtins.compareVersions version before) < 0);
   in {
-    isVersionSupported = version: versionBetween "2.070.0" "2.100.0" version;
+    isVersionSupported = version: versionBetween "2.098.1" "2.102.2" version;
   };
 }

--- a/pkgs/dmd/generic.nix
+++ b/pkgs/dmd/generic.nix
@@ -58,11 +58,6 @@
     };
   };
 
-  boolToNum = x:
-    if x
-    then "1"
-    else "0";
-
   bits = builtins.toString stdenv.hostPlatform.parsed.cpu.bits;
   os =
     if stdenv.isDarwin
@@ -94,14 +89,17 @@
     "HOST_DMD=${HOST_DMD}"
     "PIC=1"
     "BUILD=${buildMode}"
-    "ENABLE_RELEASE=${boolToNum enableRelease}"
-    "ENABLE_ASSERTS=${boolToNum enableAsserts}"
-    "ENABLE_COVERAGE=${boolToNum enableCoverage}"
-    "ENABLE_DEBUG=${boolToNum enableDebug}"
-    "ENABLE_LTO=${boolToNum enableLTO}"
-    "ENABLE_PROFILE=${boolToNum enableProfile}"
-    "ENABLE_UNITTEST=${boolToNum enableUnittest}"
-  ];
+  ]
+    # There is an "ifdef ENABLE_COVERAGE" rule in Phobos posix.max causing
+    # coverage to be enabled even if it's set to 0. For consistency we leave
+    # any false values unset.
+    ++ lib.optional enableRelease "ENABLE_RELEASE=1"
+    ++ lib.optional enableAsserts "ENABLE_ASSERTS=1"
+    ++ lib.optional enableDebug "ENABLE_DEBUG=1"
+    ++ lib.optional enableLTO "ENABLE_LTO=1"
+    ++ lib.optional enableProfile "ENABLE_PROFILE=1"
+    ++ lib.optional enableUnittest "ENABLE_UNITTEST=1"
+    ++ lib.optional enableCoverage "ENABLE_COVERAGE=1";
 in
   stdenv.mkDerivation rec {
     pname = "dmd";

--- a/pkgs/dmd/generic.nix
+++ b/pkgs/dmd/generic.nix
@@ -207,12 +207,17 @@ in
       + lib.optionalString (lib.versionAtLeast version "2.092.2") ''
         substituteInPlace ${dmdPrefix}/test/dshell/test6952.d --replace "/usr/bin/env bash" "${bash}/bin/bash"
       ''
+      # This test causes a linking failure before
+      # https://github.com/dlang/dmd/commit/cab51f946a8b2d3f0fcb856cf6c52a18a6779930
+      + lib.optionalString (lib.versionOlder version "2.103.0") ''
+        rm ${dmdPrefix}/test/runnable_cxx/cppa.d
+      ''
       + lib.optionalString stdenv.isLinux ''
         substituteInPlace phobos/std/socket.d --replace "assert(ih.addrList[0] == 0x7F_00_00_01);" ""
       ''
       + lib.optionalString stdenv.isDarwin ''
         rm ${dmdPrefix}/test/runnable/{test13117.d,test13117b.d}
-        rm ${dmdPrefix}/test/runnable_cxx/{cpp11.d,cppa.d,cpp_stdlib.d}
+        rm ${dmdPrefix}/test/runnable_cxx/{cpp11.d,cpp_stdlib.d}
 
         substituteInPlace phobos/std/socket.d --replace "foreach (name; names)" "names = []; foreach (name; names)"
       '';


### PR DESCRIPTION
~~Note: Draft since some C++ test is still failing at late phase (testing 2.102, NixOS with the current stable channel)~~

This supersedes #2

I have pulled the changes done to this repo since the original PR and reimplemented my changes on top of the latest main version.

@PetarKirov please do something this time once I get this out of draft. I do understand you want to implement the automatic hash fetcher script that will make the per-version nix files needless. I know your intention was to rebase my original MR yourself, which would solve the problem if waiting for it wasn't blocking me from doing anything else in the meantime.

However, compiler versions and NixPkgs changes keep coming, and I don't want to be blocked for months before dealing with them. In the present, I'd have to push updates to OldDDerivations with knowledge that I'll have to do them again when it comes the time to port them here. This is just unworkable - I should have to do my job only once. I think there are three possibilities:

 - Give me merge rights to this repo.
 - Merge (or request changes) to my PRs within a week or so.
 - Or, on the occasion you can't do that, don't make too much other changes before dealing with the PR so I don't have to redo it (or further PRs built on top of it).

