### PR TITLE
ci(gh-actions): Improvement to the CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,16 @@ jobs:
 
       - name: Build ${{ matrix.package }}
         run: nix build -L --json --no-link '.#${{ matrix.attrPath }}'
+
+  results:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: Final Results
+    needs: [build]
+    steps:
+      - run: exit 1
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+          }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,15 +33,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v25
-        with:
-          # NIX_PATH is explicitly set to a wrong value to prevent accidental
-          # usage. `nixpkgs` should be accessed only through the locked flake
-          # reference.
-          nix_path: nixpkgs=null
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          extra_nix_config:
-            accept-flake-config = true
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v9
+
+      - name: Run the Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v2
 
       - uses: cachix/cachix-action@v14
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
 
       - uses: cachix/cachix-action@v14
         with:
-          name: dlang-community
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          name: ${{ vars.CACHIX_CACHE }}
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Build ${{ matrix.job_name }}
         run: nix build -L --json --no-link '.#${{ matrix.pkg }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  workflow_dispatch:
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,24 +11,32 @@ on:
       - main
 
 jobs:
-  Nix:
+  generate-matrix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v9
+
+      - id: generate-matrix
+        name: Generate Nix Matrix
+        run: |
+          set -Eeu
+          matrix="$(nix eval --json '.#lib.mkGHActionsMatrix')"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+    outputs:
+      matrix: ${{ steps.generate-matrix.outputs.matrix }}
+
+  build:
+    needs: generate-matrix
     strategy:
       fail-fast: false
-      matrix:
-        experimental: [false]
-        os: [ ubuntu-latest, macos-12 ]
-        pkg:
-          - dmd
-          - ldc
-          - dub
-        include:
-          - { experimental: true, pkg: ldc, os: macos-12 }
-        exclude:
-          - { experimental: false, pkg: ldc, os: macos-12 }
+      matrix: ${{fromJSON(needs.generate-matrix.outputs.matrix)}}
 
-    name: ${{ matrix.pkg }} on ${{ matrix.os }}
+    name: ${{ matrix.package }} | ${{ matrix.system }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental }}
+    continue-on-error: ${{ matrix.allowedToFail }}
 
     steps:
       - uses: actions/checkout@v4
@@ -44,5 +52,5 @@ jobs:
           name: ${{ vars.CACHIX_CACHE }}
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      - name: Build ${{ matrix.job_name }}
-        run: nix build -L --json --no-link '.#${{ matrix.pkg }}'
+      - name: Build ${{ matrix.package }}
+        run: nix build -L --json --no-link '.#${{ matrix.attrPath }}'

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
   }:
     flake-parts.lib.mkFlake {inherit inputs;} {
       systems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
-      imports = [./pkgs];
+      imports = [./pkgs ./lib/mk-gh-actions-matrix.nix];
       perSystem = {final, ...}: {
         devShells.default = import ./shell.nix {pkgs = final;};
       };

--- a/lib/mk-gh-actions-matrix.nix
+++ b/lib/mk-gh-actions-matrix.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  self,
+  ...
+}: {
+  flake = {
+    lib = rec {
+      nixSystemToGHPlatform = {
+        "ubuntu-latest" = "x86_64-linux";
+        "macos-latest" = "x86_64-darwin";
+        # not supported:
+        # "macos-latest-xlarge" = "aarch64-darwin";
+      };
+
+      mkGHActionsMatrix = {
+        include = lib.pipe (builtins.attrNames nixSystemToGHPlatform) [
+          (builtins.concatMap
+            (
+              platform: let
+                system = nixSystemToGHPlatform.${platform};
+              in
+                map (package: let
+                  p = self.packages.${system}.${package};
+                in {
+                  os = platform;
+                  allowedToFail = builtins.elem system (p.passthru.allowedToFailOn or []);
+                  inherit system package;
+                  attrPath = "packages.${system}.${package}";
+                })
+                (builtins.attrNames self.packages.${system})
+            ))
+          (builtins.sort (a: b:
+            if (a.package == b.package)
+            then a.os == "ubuntu-latest"
+            else a.package < b.package))
+        ];
+      };
+    };
+  };
+}

--- a/pkgs/ldc/generic.nix
+++ b/pkgs/ldc/generic.nix
@@ -190,6 +190,10 @@ in
           --set-default CC "${targetPackages.stdenv.cc}/bin/cc"
     '';
 
+    passthru = {
+      allowedToFailOn = ["x86_64-darwin" "aarch64-darwin"];
+    };
+
     meta = with lib; {
       description = "The LLVM-based D compiler";
       homepage = "https://github.com/ldc-developers/ldc";


### PR DESCRIPTION
* ci(gh-actions): Enable CI workflow on workflow_dispatch (manual trigger) and merge queue
* ci(gh-actions): Use repo-wide variable for the `cachix-action` name input
* ci(gh-actions): Replace the Cachix install Nix action with Determinate Systems' action
* ci(gh-actions): Generate CI matrix automatically
* ci(pkgs/ldc): Allow failure on ["x86_64-darwin" "aarch64-darwin"]
* ci(gh-actions): Define "results" job that depends on the result of the whole matrix
